### PR TITLE
Handle edge cases

### DIFF
--- a/DirectorRework/.editorconfig
+++ b/DirectorRework/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 2
+dotnet_diagnostic.Publicizer001.severity = none
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true


### PR DESCRIPTION
Addresses the following minor issues:
- Null reference exception on elite type reset
- Broken void fields
- Inadvertently removed limit on enemies per wave
- Wave may end prematurely if a particularly expensive card is chosen
- Invalid boss title and/or combat shrine message

Also added configuration for teleporter boss.